### PR TITLE
Move advanced buttons down, so they don't overflow title

### DIFF
--- a/src/Add-on/data/YouTubePlus.css
+++ b/src/Add-on/data/YouTubePlus.css
@@ -234,6 +234,7 @@
     #watch-header{
         position: relative;
     }
+    #watch-header #watch-headline-title h1.watch-title-container{width: 100%;}
     .part_fullbrowser div#movie_player.playing-mode,
     .part_fullbrowser div#movie_player.paused-mode{
         bottom: 0;
@@ -249,12 +250,13 @@
         z-index: initial;
     }
     #advanced-options{
-        background: inherit;
         min-height: 20px;
         min-width: 25px;
         position: absolute;
         right: 0;
-        top: 0;
+        bottom: 88px;
+        margin-top: 73px;
+        background: transparent;
     }
     .part_fullbrowser #advanced-options{
         z-index: initial;
@@ -265,7 +267,7 @@
         height: 20px;
         opacity: .5;
         position: absolute;
-        top: 0;
+        top: 10px;
         right: 0;
         width: 25px;
         z-index: 1;
@@ -281,7 +283,7 @@
         display: none;
         font-size: 0;
         position: relative;
-        right: 2px;
+        right: 15px;
         top: 17px;
         text-align: center;
     }


### PR DESCRIPTION
**I suggest adding these styles, to push the buttons, bellow video, down, so they look like this:**

![1](https://user-images.githubusercontent.com/19263525/51475059-fb93c000-1d89-11e9-81c3-64012c94dccd.png)

**Instead of this:**

![2](https://user-images.githubusercontent.com/19263525/51475063-0189a100-1d8a-11e9-97df-d558ef6373af.png)


**As You can see, long titles get partly hidden.**

**With this fix it's also possible to select text above the, now pushed down, button.**

**Here are some more examples with extra long titles:**
![3](https://user-images.githubusercontent.com/19263525/51475072-08181880-1d8a-11e9-910d-122aa7922f77.png)

